### PR TITLE
fix client util escape function casting int, float to a string

### DIFF
--- a/opensearchpy/client/utils.py
+++ b/opensearchpy/client/utils.py
@@ -102,8 +102,8 @@ def _escape(value: Any) -> Any:
     elif isinstance(value, bool):
         value = str(value).lower()
 
-    # don't decode bytestrings
-    elif isinstance(value, bytes):
+    # don't decode bytestrings, int, float
+    elif isinstance(value, (bytes, int, float)):
         return value
 
     # encode strings to utf-8


### PR DESCRIPTION
### Description
_client util escape function casting int, float to a string but it should keep it as the passed value since it causes exceptions to be raised like in opensearchpy.client.OpenSearch.delete_by_query when passing the field as a normal parameter for the function._

### Issues Resolved
_ Closes #816 _ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
